### PR TITLE
Switch to alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.8-alpine
 
-RUN apk add --no-cache openjdk11-jre gcc make musl-dev
+RUN apk add --no-cache openjdk11-jre
+RUN apk add --no-cache --virtual build-dependencies gcc make musl-dev
 
 # Install Poetry & disable virtualenv creation
 RUN wget -q -O - https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
@@ -21,11 +22,13 @@ gnal-cli
 #    && ./gradlew installDist \
 #    && ln -s /tmp/signal-cli/build/install/signal-cli/bin/signal-cli /usr/bin/signal-cli
 
-
 WORKDIR /usr/src/app
 # Copy poetry.lock* in case it doesn't exist in the repo
 COPY ./pyproject.toml ./poetry.lock* ./
+
 RUN poetry install --no-root --no-dev
+RUN apk del build-dependencies
+
 COPY ./docker-start.sh ./start.sh
 RUN chmod +x start.sh
 COPY ./signal_cli_rest_api/ signal_cli_rest_api/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,25 @@
-FROM python:3.8.6-alpine
+FROM python:3.8-alpine
 
-RUN apk update \
-    && apk add --no-cache curl openjdk11-jre git gcc make musl-dev
+RUN apk add --no-cache openjdk11-jre gcc make musl-dev
 
 # Install Poetry & disable virtualenv creation
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN wget -q -O - https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false
 
 # Download & Install signal-cli
+ENV SIGNAL_CLI_VERSION=0.6.10
 RUN cd /tmp/ \
-    && git clone https://github.com/AsamK/signal-cli.git \
-    && cd signal-cli \
-    && ./gradlew build \
-    && ./gradlew installDist \
-    && ln -s /tmp/signal-cli/build/install/signal-cli/bin/signal-cli /usr/bin/signal-cli
+    && wget https://github.com/AsamK/signal-cli/releases/download/v"${SIGNAL_CLI_VERSION}"/signal-cli-"${SIGNAL_CLI_VERSION}".tar.gz \
+    && tar xf signal-cli-"${SIGNAL_CLI_VERSION}".tar.gz -C /opt \
+    && ln -s /opt/signal-cli-"${SIGNAL_CLI_VERSION}"/bin/signal-cli /usr/bin/si\
+gnal-cli
+#    && git clone https://github.com/AsamK/signal-cli.git \
+#    && cd signal-cli \
+#    && ./gradlew build \
+#    && ./gradlew installDist \
+#    && ln -s /tmp/signal-cli/build/install/signal-cli/bin/signal-cli /usr/bin/signal-cli
 
 
 WORKDIR /usr/src/app
@@ -26,4 +30,4 @@ COPY ./docker-start.sh ./start.sh
 RUN chmod +x start.sh
 COPY ./signal_cli_rest_api/ signal_cli_rest_api/
 EXPOSE 8000
-CMD ["/bin/sh", "start.sh"]
+CMD ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.8.3-buster
+FROM python:3.8.6-alpine
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget default-jre software-properties-common git locales
+RUN apk update \
+    && apk add --no-cache curl openjdk11-jre git gcc make musl-dev
 
 # Install Poetry & disable virtualenv creation
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
@@ -26,4 +26,4 @@ COPY ./docker-start.sh ./start.sh
 RUN chmod +x start.sh
 COPY ./signal_cli_rest_api/ signal_cli_rest_api/
 EXPOSE 8000
-CMD ["bash", "start.sh"]
+CMD ["/bin/sh", "start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN wget -q -O - https://raw.githubusercontent.com/python-poetry/poetry/master/g
     poetry config virtualenvs.create false
 
 # Download & Install signal-cli
-ENV SIGNAL_CLI_VERSION=0.6.10
+ENV SIGNAL_CLI_VERSION=0.6.11
 RUN cd /tmp/ \
     && wget https://github.com/AsamK/signal-cli/releases/download/v"${SIGNAL_CLI_VERSION}"/signal-cli-"${SIGNAL_CLI_VERSION}".tar.gz \
     && tar xf signal-cli-"${SIGNAL_CLI_VERSION}".tar.gz -C /opt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
 FROM python:3.8-alpine
 
 RUN apk add --no-cache openjdk11-jre
-RUN apk add --no-cache --virtual build-dependencies gcc make musl-dev
-
-# Install Poetry & disable virtualenv creation
-RUN wget -q -O - https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
-    cd /usr/local/bin && \
-    ln -s /opt/poetry/bin/poetry && \
-    poetry config virtualenvs.create false
 
 # Download & Install signal-cli
 ENV SIGNAL_CLI_VERSION=0.6.11
@@ -16,21 +9,22 @@ RUN cd /tmp/ \
     && tar xf signal-cli-"${SIGNAL_CLI_VERSION}".tar.gz -C /opt \
     && ln -s /opt/signal-cli-"${SIGNAL_CLI_VERSION}"/bin/signal-cli /usr/bin/si\
 gnal-cli
-#    && git clone https://github.com/AsamK/signal-cli.git \
-#    && cd signal-cli \
-#    && ./gradlew build \
-#    && ./gradlew installDist \
-#    && ln -s /tmp/signal-cli/build/install/signal-cli/bin/signal-cli /usr/bin/signal-cli
 
 WORKDIR /usr/src/app
 # Copy poetry.lock* in case it doesn't exist in the repo
 COPY ./pyproject.toml ./poetry.lock* ./
 
-RUN poetry install --no-root --no-dev
-RUN apk del build-dependencies
+# Install Poetry & disable virtualenv creation
+RUN wget -q -O - https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+    cd /usr/local/bin && \
+    ln -s /opt/poetry/bin/poetry && \
+    poetry config virtualenvs.create false
+    
+RUN apk add --no-cache --virtual build-dependencies gcc make musl-dev && poetry install --no-root --no-dev && apk del build-dependencies
 
 COPY ./docker-start.sh ./start.sh
 RUN chmod +x start.sh
 COPY ./signal_cli_rest_api/ signal_cli_rest_api/
+
 EXPOSE 8000
 CMD ["./start.sh"]

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 uvicorn signal_cli_rest_api.app.main:app --host 0.0.0.0


### PR DESCRIPTION
This PR replaces the Debian base image with Alpine. It also makes use of tagged signal-cli releases instead of the master branch.