### PR TITLE
[BugFix] --json option has been deprecated

### DIFF
--- a/signal_cli_rest_api/api/messages.py
+++ b/signal_cli_rest_api/api/messages.py
@@ -22,7 +22,7 @@ async def get_messages(number: str) -> Any:
     get messages
     """
 
-    response = await run_signal_cli_command(["-u", number, "receive", "--json"])
+    response = await run_signal_cli_command(["-u", number, "--output=json", "receive"])
     return [json.loads(m) for m in response.split("\n") if m != ""]
 
 


### PR DESCRIPTION
When received message, parameter error occured resulting in 500 Server Error.
```{
  "detail": "Starting signal-cli process failed: WARN ReceiveCommand - \"--json\" option has been deprecated, please use the global \"--output=json\" instead.\n"
}
```

Patch apllied to messages.py, changing the --json parameter into new --output=json and ajusting the parameter position.