### PR TITLE
[BugFix] Remove isReceipt from Envelope Validator

### DIFF
--- a/signal_cli_rest_api/api/messages.py
+++ b/signal_cli_rest_api/api/messages.py
@@ -22,7 +22,7 @@ async def get_messages(number: str) -> Any:
     get messages
     """
 
-    response = await run_signal_cli_command(["-u", number, "receive", "--json"])
+    response = await run_signal_cli_command(["-u", number, "--output=json", "receive"])
     return [json.loads(m) for m in response.split("\n") if m != ""]
 
 

--- a/signal_cli_rest_api/schemas.py
+++ b/signal_cli_rest_api/schemas.py
@@ -48,7 +48,6 @@ class Envelope(BaseModel):
     sourceDevice: int
     relay: Any
     timestamp: str
-    isReceipt: bool
     dataMessage: Optional[DataMessage] = None
 
 


### PR DESCRIPTION
On signal-cli 0.8.1, incomming message doesn't containt any isReceipt key in the JSON response, so when validating the schemas it resulting in following error:

```
 raise ValidationError(errors, field.type_)
pydantic.error_wrappers.ValidationError: 1 validation error for MessageIncoming
response -> 0 -> envelope -> isReceipt
  field required (type=value_error.missing)
```

Here is the complete example of "**new**" JSON response in incomming message:

```
{
	"envelope": {
		"source": "+6217081945001",
		"sourceDevice": 1,
		"timestamp": 1619484875616,
		"dataMessage": {
			"timestamp": 1619484875616,
			"message": "Pray for Nanggala 402",
			"expiresInSeconds": 0,
			"viewOnce": false,
			"mentions": [],
			"attachments": [],
			"contacts": []
		}
	}
}
```

Applied fix, we remove the isReceipt key from envelope schemas validator.